### PR TITLE
lib, test, tools, test: cleanup and fix debug

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -1,15 +1,10 @@
 "use strict";
 
+var debug = require("debug")("ch-arge:lib/bootstrap.js");
 var types = require("./types.js");
-var debug = require("debug")("ch-arge:bootstrap.js");
-
 var mTable = require("../tools/map-table.js").mapTable;
 var initTable = require("../tools/map-table.js").initTable;
 var docDone = require("../tools/map-table.js").saveTable;
-
-var debugMode = !process.env.DEBUG ?
-                false :
-                !!(~process.env.DEBUG.search(/ch-arge/i));
 
 exports.newType = newType;
 exports.mkRegExp = mkRegExp;
@@ -140,7 +135,7 @@ function newType (name, checkFn, aliases) {
     str = str.trim();
     return str.match(re);
   };
-  if (debugMode) reFn._name = "re" + name[0].toUpperCase() + name.slice(1);
+  if (debug.enabled) reFn._name = "re" + name[0].toUpperCase() + name.slice(1);
 
   types[name] = [reFn, checkFn];
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var debug = require("debug")("ch-arge:index.js");
+var debug = require("debug")("ch-arge:lib/index.js");
 var inherits = require("util").inherits;
 
 require("./bootstrap.js");

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -5,7 +5,7 @@
   ],
   "helpers": [
     "helpers/**/*.js",
-    "../tools/table.js"
+    "../tools/set-debug.js"
   ],
   "stopSpecOnExpectationFailure": true,
   "random": false

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,9 +1,5 @@
 "use strict";
 
-typeof process.env.DEBUG === "string" ?
-  process.env.DEBUG += ",ch-arge:bootstrap.js" :
-  process.env.DEBUG = "ch-arge:bootstrap.js";
-
 var bootstrap = require("../lib/bootstrap.js");
 var types = require("../lib/types.js");
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,5 @@
 "use strict";
 
-typeof process.env.DEBUG === "string" ? process.env.DEBUG += ",ch-arge:index.js" :
-process.env.DEBUG = "ch-arge:index.js";
-
 var charge = require("../lib");
 var types = require("../lib/types.js");
 var EE = require("events");

--- a/test/readme-table.js
+++ b/test/readme-table.js
@@ -8,8 +8,13 @@ var fn = require.resolve("../tools/table.js");
 
 describe ("...", function () {
   it ("...", function () {
+    var env = process.env,
+        opts = {env:env};
+
+    env.DEBUG = "ch-arge:tools/table.js";
+
     fn = "" + fn + "";
-    c = cp.spawnSync("node", [fn, "--compare"]);
+    c = cp.spawnSync("node", [fn, "--compare"], opts);
     console.log("child stdout: " + c.stdout);
     console.log("child stderr: " + c.stderr);
     if (c.error) fail("child errored with:", c.error.toString());

--- a/test/types.js
+++ b/test/types.js
@@ -1,9 +1,5 @@
 "use strict";
 
-typeof process.env.DEBUG === "string" ?
-  process.env.DEBUG += ",ch-arge:types.js" :
-  process.env.DEBUG = "ch-arge:types.js";
-
 require("../lib/bootstrap.js");
 var types = require("../lib/types.js");
 
@@ -193,7 +189,7 @@ describe ("bundled types", function () {
         for (var arg in nextArgs) {
           if (!nextArgs.hasOwnProperty(arg)) continue;
 
-          debug("checkFn", true, type, checkFn, nextArgs[arg]);
+          logStderr("checkFn", true, type, checkFn, nextArgs[arg]);
           expect(checkFn(nextArgs[arg])).toBe(true);
         }
 
@@ -202,7 +198,7 @@ describe ("bundled types", function () {
           if (!nextArgs) throw new Error("missing test for " + type);
           if (!nextArgs.hasOwnProperty(arg)) continue;
 
-          debug("checkFn", false, type, checkFn, nextArgs[arg]);
+          logStderr("checkFn", false, type, checkFn, nextArgs[arg]);
           expect(checkFn(nextArgs[arg])).toBe(false);
         }
       }
@@ -256,7 +252,7 @@ describe ("bundled types", function () {
           if (!strs.hasOwnProperty(ind)) continue;
 
           str = strs[ind];
-          debug("reFn", true, "<void>", reFn, str);
+          logStderr("reFn", true, "<void>", reFn, str);
           expect(reFn(str)).not.toBe(null);
         }
 
@@ -266,14 +262,14 @@ describe ("bundled types", function () {
           if (!strs.hasOwnProperty(ind)) continue;
 
           str = strs[ind];
-          debug("reFn", false, "<void>", reFn, str);
+          logStderr("reFn", false, "<void>", reFn, str);
           expect(reFn(str)).toBe(null);
         }
       }
     });
   });
 
-  function debug (section, goodArg, expType, checkFn, subj) {
+  function logStderr (section, goodArg, expType, checkFn, subj) {
     var util = require("util");
     if (process.env.no_debug) return;
     var com = ",",

--- a/tools/map-table.js
+++ b/tools/map-table.js
@@ -1,20 +1,25 @@
 "use strict";
 
-var table, curry = 0, fs, ghmd_table, path;
+var table, curry = 0, fs, ghmd_table;
 
-if (/ch-arge:table.js/i.test(process.env.DEBUG || "")) {
+if (/ch-arge:tools\/table.js/i.test(process.env.DEBUG || "")) {
   module.exports = {
     mapTable: mapTable,
     saveTable: saveTable,
     initTable: initTable,
     table: null
   };
+
   ghmd_table = require("ghmd-table");
   table = new ghmd_table.Table;
   fs = require("fs");
-  path = require("path");
 } else {
-  module.exports = function NOP () {};
+  module.exports = {
+    mapTable: NOP,
+    saveTable: NOP,
+    initTable: NOP,
+    table: null
+  };
 }
 
 function mapTable (type, aliases) {
@@ -36,3 +41,5 @@ function initTable () {
 function saveTable () {
   module.exports.table = table;
 }
+
+function NOP () {}

--- a/tools/set-debug.js
+++ b/tools/set-debug.js
@@ -1,0 +1,41 @@
+"use strict";
+
+var assert = require("assert");
+
+/**
+  * Assuming npm debug @ 2.2.0
+  */
+
+process.env.DEBUG === undefined ? process.env.DEBUG = "" : void 0;
+process.env.DEBUG_COLORS === undefined ?
+  process.env.DEBUG_COLORS = "yes" : void 0;
+assert.strictEqual(true, setMode("ch-arge:lib/bootstrap.js"));
+assert.strictEqual(true, setMode("ch-arge:lib/index.js"));
+// NOTE currently this one isn't used at all
+assert.strictEqual(true, setMode("ch-arge:lib/types.js"));
+// NOTE not used in par process (is set for child in test/readme-table.js tho)
+// but when it's set debug() will log in the first color again b/c it's been
+// loaded again (i think cyan)
+// assert.strictEqual(true, setMode("ch-arge:tools/table.js"));
+
+/**
+  * Adds namespace to `process.env.DEBUG` if not there already.
+  * NOTE: namespace is typed to RegExp implicitly
+  */
+function setMode (namespace) {
+  var DEBUG = process.env.DEBUG,
+      regexp = new RegExp(escape(namespace), "i"),
+      pre;
+
+  if (undefined === DEBUG) throw new Error("`process.env.DEBUG` => undefined");
+  if (regexp.test(DEBUG)) return false;
+  else {
+    DEBUG.length ? pre = "," : pre = "";
+    process.env.DEBUG = DEBUG += pre + namespace;
+    return true;
+  }
+
+  function escape (string) {
+    return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  }
+}

--- a/tools/table.js
+++ b/tools/table.js
@@ -3,21 +3,10 @@
 // env below, make sure we execute before the initial require("./bootstrap.js").
 // As of now, we do this in helpers of jasmine.json
 
-typeof process.env.DEBUG === "string" ?
-  process.env.DEBUG += ",ch-arge:table.js" :
-  process.env.DEBUG = "ch-arge:table.js";
-
-  // TEMP fix for below
-  typeof process.env.DEBUG === "string" ?
-    process.env.DEBUG += ",ch-arge:bootstrap.js" :
-    process.env.DEBUG = "ch-arge:bootstrap.js";
-process.env.DEBUG_COLORS = "yes";
-
-
 var fs = require("fs");
 var ghmd_table = require("ghmd-table");
 var mapTable = require("./map-table.js");
-var debug = require("debug")("ch-arge:table.js");
+var debug = require("debug")("ch-arge:tools/table.js");
 
 var tableSeparator = "<!--0000-->\r\n";
 var targFile = require.resolve("../README.md");
@@ -57,15 +46,8 @@ function compare (abrupt, _update) {
   // to compare, it is necessary that bootstrap.js has loaded so we can acces
   // table which is exposed by it
   if (table === null) {
-    debug(
-          "compare(), mapTable inactive, loading 'bootstrap.js' %s",
-          debug.enabled ? "in debug mode" : ""
-        );
-    // FIXME
-    if (debug.enabled)
-    /*typeof process.env.DEBUG === "string" ?
-      process.env.DEBUG += ",ch-arge:bootstrap.js" :
-      process.env.DEBUG = "ch-arge:bootstrap.js"*/;
+    // FIXME should we log() or debug() ???
+    debug("compare(), `mapTable` inactive, loading 'bootstrap.js'");
     require("../lib/bootstrap.js");
     table = mapTable.table;
     if (table === null) throw new Error("Unexpected table -> null");


### PR DESCRIPTION
TIL The npm debug pkg loads `process.env.DEBUG` once (when it's `require()`d)
and never again, so the namespaces being added after the first
`require("debug")` where disabled because node caches after the first load and
currently there is no way to force load every time.

This also cleans up a lot of debug namespace modification areas that were
frustratingly added when trying to figure this shit out.
