### PR TITLE
lib: add `opt.message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,22 +73,22 @@ The constructor for the error thrown if `opts.shouldThrow` is on, inherits from 
 Type|Aliases|
 :---|:---
 Object|Object object Obj obj</br>
-Array|Array array Arr arr
-Function|Function function</br>Fn fn Func func
-RegExp|RegExp regexp regExp</br>Regexp
-Date|Date date
+Array|Array array Arr arr 
+Function|Function function</br>Fn fn Func func 
+RegExp|RegExp regexp regExp</br>Regexp 
+Date|Date date 
 Symbol|Symbol symbol Sym sym</br>
-String|String Str
-Number|Number Num
-Boolean|Boolean Bool
-null|null
-undefined|undefined
-string|string str
-number|number num
-integer|integer int
-float|float flt
-boolean|boolean bool
-NaN|NaN Nan naN nan
+String|String Str 
+Number|Number Num 
+Boolean|Boolean Bool 
+null|null 
+undefined|undefined 
+string|string str 
+number|number num 
+integer|integer int 
+float|float flt 
+boolean|boolean bool 
+NaN|NaN Nan naN nan 
 <!--0000-->
 
 ### How Bundled Types are Determined

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Returns a boolean, depending on the actual matching any (or all if
     Defaults to true.
   * `singleCheck`, if false will pass if it matches all given expected types.
     Defaults to true.
+  * `message`, if provided will override the default ArgError message.  Must be
+    a string, or else will error.
 
 ### `charge.newType ([name], checkFn, alias1 [,alias2] [,alias...])`
 Defines a new type known by name (if provided) and aliases.  Returns name.
@@ -71,22 +73,22 @@ The constructor for the error thrown if `opts.shouldThrow` is on, inherits from 
 Type|Aliases|
 :---|:---
 Object|Object object Obj obj</br>
-Array|Array array Arr arr 
-Function|Function function</br>Fn fn Func func 
-RegExp|RegExp regexp regExp</br>Regexp 
-Date|Date date 
+Array|Array array Arr arr
+Function|Function function</br>Fn fn Func func
+RegExp|RegExp regexp regExp</br>Regexp
+Date|Date date
 Symbol|Symbol symbol Sym sym</br>
-String|String Str 
-Number|Number Num 
-Boolean|Boolean Bool 
-null|null 
-undefined|undefined 
-string|string str 
-number|number num 
-integer|integer int 
-float|float flt 
-boolean|boolean bool 
-NaN|NaN Nan naN nan 
+String|String Str
+Number|Number Num
+Boolean|Boolean Bool
+null|null
+undefined|undefined
+string|string str
+number|number num
+integer|integer int
+float|float flt
+boolean|boolean bool
+NaN|NaN Nan naN nan
 <!--0000-->
 
 ### How Bundled Types are Determined

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,8 +9,16 @@ var newType = require("./bootstrap.js").newType;
 
 inherits(ArgError, Error);
 // ArgError definition
-function ArgError () {
+function ArgError (message) {
   if (!(this instanceof ArgError)) return ArgError.apply(this, arguments);
+  // NOTE Error is a factory function, will return a new object regardless, so
+  // Error.apply(this, arguments) will not work
+  var e = /*new*/ Error(message);
+  // NOTE must use Object.getOwnPropertyNames() bc .stack and .message are
+  // non-enumerable
+  Object.getOwnPropertyNames(e).forEach(function (key) {
+    this[key] = e[key];
+  }, this);
   this.name = "ArgError";
 }
 
@@ -36,10 +44,15 @@ module.exports = function (arg) {
 
   var checkQueue = [], already = [], alreadyC = [];
   var fn, reRes, res, lastArg, lastArgObj, shouldThrow, singleCheck,
-      iterFn, exp, _arguments, opts;
+      iterFn, exp, _arguments, opts, message;
 
   shouldThrow = ("shouldThrow" in opts) ? !!opts.shouldThrow : true;
   singleCheck = ("singleCheck" in opts) ? !!opts.singleCheck : true;
+  message = ("message" in opts ?
+              opts.message :
+              "Wrong type: " + require("util").inspect(arg));
+  if (typeof message !== "string")
+    throw new TypeError("'message' must be type string");
   iterFn = singleCheck === false ?
     Array.prototype.every :
     Array.prototype.some;
@@ -93,7 +106,7 @@ module.exports = function (arg) {
     });
     debug("res " + res);
 
-    if (shouldThrow && false === res) throw new ArgError("Invalid arg: " + arg);
+    if (shouldThrow && false === res) throw new ArgError(message);
     else return res;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,16 @@ describe("parameters", function () {
     });
   });
 
+  it ("`message`", function () {
+    // default
+    expect(charge.bind(null, "sss", "obj")).toThrowError("Wrong type: 'sss'");
+    // custom
+    expect(charge.bind(null, "", "obj", {message: "bad"})).toThrowError("bad");
+    // wrong message type
+    expect(charge.bind(null, true, "bool", {message: {}})).
+    toThrowError(/'message' must be type string/);
+  });
+
   it ("negated type", function () {
     // negated
     expect (


### PR DESCRIPTION
New opt, `message`, allows you to pass a custom ArgError message if provided.
It must be type string or else will throw.

Fixes: #24
